### PR TITLE
Allow for resizing of the Search Bar & README change

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ I was always inspired to make this because I was always a bit sad that many comm
 💻 Click clock to convert to 24-hour/12-hour clocks<br>
 💻 Click movie information to customize format (name, Japanese name, screen time, quote, year released)<br>
 💻 Right click to-do list to cross out items<br>
-💻 Click right hand side of search bar to switch between Google, Duckduckgo, Bing, and Yahoo<br><br>
+💻 Click right hand side of search bar to switch between Google, Duckduckgo, Bing, and Yahoo<br>
+💻 Click left hand side of search bar to switch between small and large<br><br>
 ![chrome-capture-2022-3-25 (5)](https://user-images.githubusercontent.com/40601891/165195395-45dfe764-35cc-4301-ada3-bda149823ad8.gif)
 ![chrome-capture-2022-3-25 (6)](https://user-images.githubusercontent.com/40601891/165195666-7715bee3-f570-40f8-91db-a22c23d1300a.gif)<br>
 ✅ Move mouse to right side of screen to access widgets (breathing, weather, gif)<br>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![marquee-giblify](https://user-images.githubusercontent.com/40601891/165597366-b27eea5b-948d-4dbc-a2e3-c51e4909afc5.png)
 
-#   ![heen-small](https://user-images.githubusercontent.com/40601891/165597566-3c6fa7fa-0553-4ec2-80cc-bee568ce7a6b.gif) ghiblify2 new tab chrome extension
+# ![heen-small](https://user-images.githubusercontent.com/40601891/165597566-3c6fa7fa-0553-4ec2-80cc-bee568ce7a6b.gif) ghiblify2 new tab chrome extension
 
 Replace new tab page with a personal, studio ghibli-inspired tab, tailored to your liking. Every refresh is another chance for another picture. This page is flexible to many preferences, allowing you to get the most out of every new tab.<br>
 
@@ -18,7 +18,7 @@ I was always inspired to make this because I was always a bit sad that many comm
 🌄 NEW animated backgrounds<br>
 🌄 NEW beta anime animations (calm)<br><br>
 ![chrome-capture-2022-3-25 (4)](https://user-images.githubusercontent.com/40601891/165195018-346683bb-0d72-4db7-9be1-799f61d243c0.gif)
-  ![chrome-capture-2022-3-25 (2)](https://user-images.githubusercontent.com/40601891/165194432-8af2d46d-c073-4f0e-a6fe-844fbbba5848.gif)
+![chrome-capture-2022-3-25 (2)](https://user-images.githubusercontent.com/40601891/165194432-8af2d46d-c073-4f0e-a6fe-844fbbba5848.gif)
 
 💻 Widgets you can put on dashboard: Clock, search bar, movie information, to-do list<br>
 💻 Toggle widgets on and off on left-hand bar<br>
@@ -28,19 +28,24 @@ I was always inspired to make this because I was always a bit sad that many comm
 💻 Right click to-do list to cross out items<br>
 💻 Click right hand side of search bar to switch between Google, Duckduckgo, Bing, and Yahoo<br><br>
 ![chrome-capture-2022-3-25 (5)](https://user-images.githubusercontent.com/40601891/165195395-45dfe764-35cc-4301-ada3-bda149823ad8.gif)
-![chrome-capture-2022-3-25 (6)](https://user-images.githubusercontent.com/40601891/165195666-7715bee3-f570-40f8-91db-a22c23d1300a.gif)
+![chrome-capture-2022-3-25 (6)](https://user-images.githubusercontent.com/40601891/165195666-7715bee3-f570-40f8-91db-a22c23d1300a.gif)<br>
 ✅ Move mouse to right side of screen to access widgets (breathing, weather, gif)<br>
 ✅ Toggle widgets on and off<br>
 
 ### Usage
+
 All pictures taken from online sources, credit to Studio Ghibli.<br>
+
 ### Browser Permissions
+
 These are the permission that the `manifest.json` asks for:
+
 - Storage: To store the data relating to preferences and widgets
 - Geolocation: To access weather information from OpenWeather API
 - Tabs: to oepn in new tab
 
 ### Code
+
 - JQuery
 - JavaScript
 - HTML

--- a/index.html
+++ b/index.html
@@ -200,6 +200,7 @@
     <!-- the search bar widget -->
     <div class="searchWrapper" ID="searchWrapper">
       <div class="searchDiv" ID="searchDiv"></div>
+      <div id="searchSizeChange">⯈</div>
       <form id=search action="https://www.google.com/search" method="get">
         <input id="searchInput" class="search" data-placeholder=" Google Search" type="searh" name="q" autocomplete="off" />
         <input type="submit" style="display: none;" />

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -214,7 +214,11 @@ function updateSearch() {
 
 //Search bar: changes search bar size
 function changeSearchSize(){
-  console.log("change search size clicked")
+  if(document.getElementById("searchInput").classList[0] === 'search'){
+    document.getElementById("searchInput").classList.replace('search', 'searchLarge')
+  }else{
+    document.getElementById("searchInput").classList.replace('searchLarge', 'search')
+  }
 }
 
 //Search bar: changes the search engine

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -215,8 +215,14 @@ function updateSearch() {
 //Search bar: changes search bar size
 function changeSearchSize(){
   if(document.getElementById("searchInput").classList[0] === 'search'){
+    chrome.storage.local.set({
+      search_large: 'true'
+    }, function() {});
     document.getElementById("searchInput").classList.replace('search', 'searchLarge')
   }else{
+    chrome.storage.local.set({
+      search_large: 'false'
+    }, function() {});
     document.getElementById("searchInput").classList.replace('searchLarge', 'search')
   }
 }
@@ -1527,7 +1533,8 @@ $(document).ready(function() {
     search_switch: 'on',
     search_top_data: '',
     search_left_data: '',
-    search_engine: 0
+    search_engine: 0,
+    search_large: 'false'
   }, function(data) {
     if (data.search_switch == 'off') {
       document.getElementById("searchSwitch").checked = false;
@@ -1542,6 +1549,9 @@ $(document).ready(function() {
     }
     if (data.search_left_data != '') {
       document.getElementById("searchWrapper").style.left = data.search_left_data;
+    }
+    if(data.search_large != 'false'){
+      document.getElementById("searchInput").classList.replace('search', 'searchLarge')
     }
 
     let searchInput = $('#searchInput');

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -212,7 +212,12 @@ function updateSearch() {
   }
 }
 
-//Search bar: chaanges the search engine
+//Search bar: changes search bar size
+function changeSearchSize(){
+  console.log("change search size clicked")
+}
+
+//Search bar: changes the search engine
 function changeSearch() {
   chrome.storage.local.get({
     search_engine: 0
@@ -1594,6 +1599,9 @@ $(document).ready(function() {
   //setting the switches click event listeners
   document.getElementById("searchSwitch").parentElement.addEventListener('click', function() {
     updateSearch();
+  });
+  document.getElementById("searchSizeChange").addEventListener("click", function() {
+    changeSearchSize();
   });
   document.getElementById("searchChange").addEventListener("click", function() {
     changeSearch();

--- a/styles/index.css
+++ b/styles/index.css
@@ -210,6 +210,22 @@ h2 {
    cursor: move;
  }
 
+ /* change search size button */
+ #searchSizeChange {
+  position: absolute;
+  top: 35%;
+  left: -25px;
+  font-size: 20px;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0);
+  transition: 0.25s;
+  user-select: none;
+}
+
+#searchSizeChange:hover {
+  color: rgba(255, 255, 255, 0.3);
+}
+
  /* change search button */
  #searchChange {
    position: absolute;

--- a/styles/index.css
+++ b/styles/index.css
@@ -204,6 +204,18 @@ h2 {
    border-color: rgba(255, 255, 255, 0.2) !important;
  }
 
+ .searchLarge {
+  padding: 5px;
+  border-radius: 7px;
+  color: rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0) !important;
+  font-size: 20px;
+  font-family: "HelveticaNeue-Light", "open sans Light", "open sans", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-weight: 100;
+  width: 36vw;
+  border-color: rgba(255, 255, 255, 0.2) !important;
+}
+
  /* movable part of search widget */
  .searchDiv {
    padding: 5px;


### PR DESCRIPTION
### I raised an issue regarding the resizing of the search bar and a small README change.

In this PR I have created a working resizable search bar which utilises chrome local storage. It has two sizes - 

- The initial size of the search bar that was already part of the code base (18vw)
- The new 'large' search bar (36vw)

The button to toggle this behaviour has been placed on the left side of the search bar and follows the same styling as the search engine change button. The only variation in it's CSS is the use of `left: -25px` instead of the `right: -25px` for the search engine toggle.


I additionally edited the README to address the small formatting error I noticed by using an additional `<br>` tag and I also added the new resizing feature to the bottom of the feature list.

This should close issue #1. 